### PR TITLE
fix(slide): relax Imagen safety filter to allow illustration generation

### DIFF
--- a/backend/src/constants/slide.py
+++ b/backend/src/constants/slide.py
@@ -78,6 +78,7 @@ PIL_FONT_MAP = {
 
 GEMINI_MODEL_NAME = "gemini-2.5-flash"
 IMAGEN_MODEL_NAME = "imagen-4.0-generate-001"
+IMAGEN_SAFETY_FILTER_LEVEL = "BLOCK_MEDIUM_AND_ABOVE"
 
 SLIDE_CATEGORIES = {
     "sales_proposal": "営業提案書",

--- a/backend/src/infrastructure/external/gemini_client.py
+++ b/backend/src/infrastructure/external/gemini_client.py
@@ -18,7 +18,12 @@ from backend.src.constants.prompts import (
     CHART_DATA_INSTRUCTIONS,
     REVISE_SINGLE_SLIDE_PROMPT,
 )
-from backend.src.constants.slide import DEFAULT_CATEGORY, GEMINI_MODEL_NAME, IMAGEN_MODEL_NAME
+from backend.src.constants.slide import (
+    DEFAULT_CATEGORY,
+    GEMINI_MODEL_NAME,
+    IMAGEN_MODEL_NAME,
+    IMAGEN_SAFETY_FILTER_LEVEL,
+)
 from backend.src.domain.commons.result import Result, failure, success
 from backend.src.domain.repositories.slide.ai_slide_repository import AiSlideRepository
 
@@ -134,7 +139,7 @@ class GeminiAiSlideRepository(AiSlideRepository):
                 prompt=prompt,
                 config=types.GenerateImagesConfig(
                     number_of_images=1,
-                    safety_filter_level="BLOCK_LOW_AND_ABOVE",
+                    safety_filter_level=IMAGEN_SAFETY_FILTER_LEVEL,
                 ),
             )
         except Exception as e:


### PR DESCRIPTION
## Summary
- Imagen 4 API の `safety_filter_level` を `BLOCK_LOW_AND_ABOVE`（最も厳しい）から `BLOCK_MEDIUM_AND_ABOVE` に緩和し、ビジネス系イラストがブロックされないようにした
- 安全フィルタレベルを `constants/slide.py` で定数管理するようにした

Closes #14

## Changes
| File | Change |
|------|--------|
| `backend/src/constants/slide.py` | `IMAGEN_SAFETY_FILTER_LEVEL` 定数を追加 |
| `backend/src/infrastructure/external/gemini_client.py` | ハードコード値を定数参照に置換 |

## Test Plan
- [x] ユニットテスト 33件 全パス
- [x] インテグレーションテスト 14件 全パス
- [ ] デプロイ後にイラスト付きスライドが生成されることを確認

## Untested Features
- 実際の Imagen API 呼び出しによるイラスト生成確認（API キーが必要なためローカルでは不可、デプロイ後に確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)