### PR TITLE
fix(slide): switch from Imagen 4 to Gemini native image generation

### DIFF
--- a/backend/src/constants/slide.py
+++ b/backend/src/constants/slide.py
@@ -77,8 +77,8 @@ PIL_FONT_MAP = {
 }
 
 GEMINI_MODEL_NAME = "gemini-2.5-flash"
-IMAGEN_MODEL_NAME = "imagen-4.0-generate-001"
-IMAGEN_SAFETY_FILTER_LEVEL = "BLOCK_MEDIUM_AND_ABOVE"
+GEMINI_IMAGE_MODEL_NAME = "gemini-2.5-flash-preview-image-generation"
+GEMINI_IMAGE_ASPECT_RATIO = "3:4"
 
 SLIDE_CATEGORIES = {
     "sales_proposal": "営業提案書",

--- a/backend/src/infrastructure/external/gemini_client.py
+++ b/backend/src/infrastructure/external/gemini_client.py
@@ -20,9 +20,9 @@ from backend.src.constants.prompts import (
 )
 from backend.src.constants.slide import (
     DEFAULT_CATEGORY,
+    GEMINI_IMAGE_ASPECT_RATIO,
+    GEMINI_IMAGE_MODEL_NAME,
     GEMINI_MODEL_NAME,
-    IMAGEN_MODEL_NAME,
-    IMAGEN_SAFETY_FILTER_LEVEL,
 )
 from backend.src.domain.commons.result import Result, failure, success
 from backend.src.domain.repositories.slide.ai_slide_repository import AiSlideRepository
@@ -131,25 +131,32 @@ class GeminiAiSlideRepository(AiSlideRepository):
         return success(parsed)
 
     def generate_image(self, prompt: str) -> Result[bytes, Exception]:
-        logger.info("Imagen API call start: model=%s, prompt=%s", IMAGEN_MODEL_NAME, prompt[:80])
+        logger.info("Gemini image generation start: model=%s, prompt=%s", GEMINI_IMAGE_MODEL_NAME, prompt[:80])
         try:
             client = self._get_client()
-            response = client.models.generate_images(
-                model=IMAGEN_MODEL_NAME,
-                prompt=prompt,
-                config=types.GenerateImagesConfig(
-                    number_of_images=1,
-                    safety_filter_level=IMAGEN_SAFETY_FILTER_LEVEL,
+            response = client.models.generate_content(
+                model=GEMINI_IMAGE_MODEL_NAME,
+                contents=prompt,
+                config=types.GenerateContentConfig(
+                    response_modalities=["IMAGE"],
+                    image_config=types.ImageConfig(
+                        aspect_ratio=GEMINI_IMAGE_ASPECT_RATIO,
+                    ),
                 ),
             )
         except Exception as e:
-            logger.error("Imagen API exception: %s: %s", type(e).__name__, e)
+            logger.error("Gemini image generation exception: %s: %s", type(e).__name__, e)
             return failure(e)
 
-        if not response.generated_images:
-            logger.warning("Imagen API returned no images for prompt: %s", prompt[:80])
+        if not response.candidates or not response.candidates[0].content.parts:
+            logger.warning("Gemini image generation returned no image for prompt: %s", prompt[:80])
             return failure(Exception("No image generated"))
 
-        image_bytes = response.generated_images[0].image.image_bytes
-        logger.info("Imagen API success: %d bytes", len(image_bytes))
-        return success(image_bytes)
+        for part in response.candidates[0].content.parts:
+            if part.inline_data:
+                image_bytes = part.inline_data.data
+                logger.info("Gemini image generation success: %d bytes", len(image_bytes))
+                return success(image_bytes)
+
+        logger.warning("Gemini image generation returned no inline_data for prompt: %s", prompt[:80])
+        return failure(Exception("No image data in response"))


### PR DESCRIPTION
## Summary

- Imagen 4 API (`imagen-4.0-generate-001`) の日次クォータ（70リクエスト/日）超過により画像生成が全て失敗していた問題を修正
- Gemini ネイティブ画像生成（`gemini-2.5-flash-preview-image-generation`）に切り替え（500リクエスト/日の無料枠）
- `generate_images()` → `generate_content()` with `response_modalities=["IMAGE"]` に変更

## Changes

- `backend/src/constants/slide.py`: `IMAGEN_MODEL_NAME` / `IMAGEN_SAFETY_FILTER_LEVEL` → `GEMINI_IMAGE_MODEL_NAME` / `GEMINI_IMAGE_ASPECT_RATIO`
- `backend/src/infrastructure/external/gemini_client.py`: `generate_image()` メソッドを Gemini ネイティブ画像生成 API に書き換え

## Test plan

- [x] ユニットテスト 33件パス
- [x] インテグレーションテスト 14件パス

## Untested Features

- Gemini ネイティブ画像生成の実際の API 呼び出し（外部 API のためモックでテスト。デプロイ後に実機確認が必要）

Closes #16